### PR TITLE
Fix creating a fully static binary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,17 +81,24 @@ lazy val scalals =
     .nativeSettings(
       nativeConfig ~= { config =>
         val nixCC = sys.env.get("NIX_CC")
+
         val cc = for {
           n <- nixCC
           c <- sys.env.get("CC")
         } yield s"$n/bin/$c"
+
         val cxx = for {
           n <- nixCC
           c <- sys.env.get("CXX")
         } yield s"$n/bin/$c"
 
+        val nixCFlagsLink = for {
+          flags <- sys.env.get("NIX_CFLAGS_LINK").toList
+          flag <- flags.split(" +") if flag.nonEmpty
+        } yield flag
+
         config
-          .withLinkingOptions(List("-fuse-ld=lld"))
+          .withLinkingOptions("-fuse-ld=lld" +: nixCFlagsLink)
           .withClang(cc.fold(config.clang)(Paths.get(_)))
           .withClangPP(cxx.fold(config.clangPP)(Paths.get(_)))
       },

--- a/flake.nix
+++ b/flake.nix
@@ -99,10 +99,8 @@
               SCALANATIVE_MODE = "release-full"; # {debug, release-fast, release-full}
               SCALANATIVE_LTO = "thin"; # {none, full, thin}
 
-              buildPhase = lib.optionalString (stdenvStatic.isLinux) ''
-                NIX_LDFLAGS="-static $NIX_LDFLAGS"
-              '' + ''
-                NIX_LDFLAGS="$NIX_LDFLAGS -L${empty-gcc-eh}/lib"
+              buildPhase = ''
+                export NIX_LDFLAGS="$NIX_LDFLAGS -L${empty-gcc-eh}/lib"
 
                 sbt 'project scalalsNative' 'show nativeConfig' nativeLink
               '';


### PR DESCRIPTION
Using `NIX_LDFLAGS` to pass in the `-static` flag does not work, since the CC wrapper decides early on (using the `checkLinkType` helper funtion) if the link type is dynamic or not, only looking at the passed arguments (and response files). Depending on this, it will then pass the `-dynamic-linker` flag to the linker which we need to avoid.

We need to pass `-static` directly when invoking the CC wrapper. Fortunately, the `NIX_CFLAGS_LINK` variable already contains this flag (on Linux).