### PR TITLE
Build scalals for riscv64

### DIFF
--- a/.github/crosscompile
+++ b/.github/crosscompile
@@ -7,6 +7,7 @@ declare -ar TARGETS=(
     x86_64-apple-darwin-none
     aarch64-unknown-linux-musl
     aarch64-apple-darwin-none
+    riscv64-unknown-linux-musl
 )
 
 echo '::group::configure'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,8 @@ jobs:
         SCALANATIVE_MODE: ${{ github.ref == 'refs/heads/main' && 'release-full' || 'debug' }}
     - name: qemu-aarch64 scalals
       run: nix shell 'nixpkgs#qemu' --command qemu-aarch64 scalals-linux-aarch64
+    - name: qemu-risc64 scalals
+      run: nix shell 'nixpkgs#qemu' --command qemu-riscv64 scalals-linux-riscv64
     - uses: actions/upload-artifact@v4
       with:
         path: scalals-*


### PR DESCRIPTION
~Note, LTO does not currently work for this target, it fails with~ (zig 0.12 works)
```
ld.lld: error: linking module flags 'SmallDataLimit': IDs have conflicting values in '/home/claudio/.cache/zig/o/d1ff36a3d6a90e8dbbd0454b1788f077/libc++abi.a(cxa_exception.o at 416660)' and 'ld-temp.o'
```