### PR TITLE
Set CPU to sandybridge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,25 @@ jobs:
     - run: nix develop '.#graalVM' --command sbt 'scalalsJVM / GraalVMNativeImage / packageBin'
     - run: jvm/target/graalvm-native-image/scalals
 
+  package:
+    name: Nix ❄
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Install Nix ❄"
+      uses: cachix/install-nix-action@v26
+    - name: "Install Cachix ❄"
+      uses: cachix/cachix-action@v14
+      with:
+        name: cbley
+        extraPullNames: pre-commit-hooks
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        pushFilter: '[-](source|nixpkgs-src)$'
+    - run: git branch PR-${{ github.event.number }}
+    - run: nix flake check
+    - run: nix build --print-build-logs
+    - run: nix run
+
   tests:
     runs-on: ubuntu-latest
     steps:
@@ -74,9 +93,6 @@ jobs:
         # Only needed for private caches
         #authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: git branch PR-${{ github.event.number }}
-    - run: nix flake check
-    - run: nix build --print-build-logs
-    - run: nix run
     - run: nix develop --ignore-environment --keep HOME --command '.github/crosscompile'
     - run: nix shell 'nixpkgs#qemu' --command qemu-aarch64 scalals-out-linux-aarch64
     - uses: actions/upload-artifact@v4

--- a/build.sbt
+++ b/build.sbt
@@ -108,12 +108,18 @@ lazy val scalals =
       targetTriplet := None,
       nativeConfig := {
         val config = nativeConfig.value
+        val nixCFlagsCompile = for {
+          flags <- sys.env.get("NIX_CFLAGS_COMPILE").toList
+          flag <- flags.split(" +") if flag.nonEmpty
+        } yield flag
+
         val nixCFlagsLink = for {
           flags <- sys.env.get("NIX_CFLAGS_LINK").toList
           flag <- flags.split(" +") if flag.nonEmpty
         } yield flag
 
         config
+          .withCompileOptions(nixCFlagsCompile)
           .withLinkingOptions("-fuse-ld=lld" :: nixCFlagsLink)
           .withTargetTriple(targetTriplet.value)
       },

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,8 @@
               SCALANATIVE_LTO = "thin"; # {none, full, thin}
               XDG_CACHE_HOME = "xdg_cache"; # needed by zig cc for a writable directory
 
+              NIX_CFLAGS_COMPILE = pkgs.lib.optional (with pkgs.stdenv; isLinux && isx86_64) "-march=sandybridge";
+
               buildPhase = ''
                 sbt 'project scalalsNative' 'show nativeConfig' ninjaCompile ninja
                 ninja -f native/target/scala-3.3.3/native/build.ninja


### PR DESCRIPTION
Running `nix run github:avdv/scalals` on my faithful T420 resulted in the process being killed by a SIGILL signal.

The binary contained a `mulx` instruction, which is from Intel's Haswell processor line, requiring the bmi2 cpu feature.

By adding `-mcpu=sandybridge` on x86_64 linux we restrict the instruction set and it runs on my machine.