### PR TITLE
Fix wrong git status getting reported

### DIFF
--- a/shared/src/main/scala/de/bley/scalals/Particles.scala
+++ b/shared/src/main/scala/de/bley/scalals/Particles.scala
@@ -163,9 +163,7 @@ object GitDecorator extends Decorator:
         val file = line.substring(3)
 
         // skip next line for renames
-        if mode.contains('R') then
-          while iter.hasNext && iter.next() != '\u0000' do {}
-          if iter.hasNext then iter.next() // discard NUL byte
+        if mode.contains('R') then while iter.hasNext && iter.next() != '\u0000' do {}
 
         val f = Paths.get(file.stripPrefix(prefix)).subpath(0, 1).toString
 


### PR DESCRIPTION
We skipped another character after the NUL byte actually, which was the first mode character
of the next entry.
