### PR TITLE
Update nixpkgs to nixos-24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,16 +88,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716218643,
-        "narHash": "sha256-i/E7gzQybvcGAYDRGDl39WL6yVk30Je/NXypBz6/nmM=",
+        "lastModified": 1717281328,
+        "narHash": "sha256-evZPzpf59oNcDUXxh2GHcxHkTEG4fjae2ytWP85jXRo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8695cbd09a7ecf3376bd62c798b9864d20f86ee",
+        "rev": "b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "scalals";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     nix-filter.url = "github:numtide/nix-filter";
     flake-compat = {
       url = "github:edolstra/flake-compat";

--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,14 @@
 
             graalVM = pkgs.mkShell {
               name = "scalals / graalvm";
+
+              # Workaround GraalVM issue where the builder does not have access to the
+              # environment variables since 21.0.0
+              # https://github.com/oracle/graal/pull/6095
+              # https://github.com/oracle/graal/pull/6095
+              # https://github.com/oracle/graal/issues/7502
+              NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION = "true";
+
               shellHook = ''
                 ${checks.pre-commit-check.shellHook}
               '';


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a8695cbd09a7ecf3376bd62c798b9864d20f86ee' (2024-05-20)
  → 'github:NixOS/nixpkgs/b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1' (2024-06-01)
