### PR TITLE
Upgrade to scala-native 0.5

### DIFF
--- a/.github/crosscompile
+++ b/.github/crosscompile
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 declare -ar TARGETS=(
-    x86_64-linux-musl
-    x86_64-macos-none
-    aarch64-linux-musl
-    aarch64-macos-none
+    x86_64-unknown-linux-musl
+    x86_64-apple-darwin-none
+    aarch64-unknown-linux-musl
+    aarch64-apple-darwin-none
 )
 
 echo '::group::compile'
@@ -24,9 +24,11 @@ for target in "${TARGETS[@]}"; do
         *macos*) LTO=none ;;
         *)       LTO=full ;;
     esac
+
     echo "::group::build $target"
+
     sbt -client "set nativeConfig ~= { _.withLTO(scala.scalanative.build.LTO.$LTO) }"
-    sbt -client "set targetTriplet := Some(\"$target\")"
+    sbt -client "set targetTriplet:= Some(\"$target\")"
     sbt -client "ninja"
     ninja -f native/target/scala-3.4.2/native/build.ninja
     echo '::endgroup::'

--- a/.github/crosscompile
+++ b/.github/crosscompile
@@ -9,13 +9,13 @@ declare -ar TARGETS=(
     aarch64-apple-darwin-none
 )
 
-echo '::group::compile'
+echo '::group::configure'
 sbt -client 'project scalalsNative'
+echo '::endgroup::'
 
 # Mode: {debug, release-fast, release-full, release-size}
 
-sbt -client 'ninjaCompile'
-echo '::endgroup::'
+declare -a binaries
 
 for target in "${TARGETS[@]}"; do
     # LTO: {none, full, thin}
@@ -30,10 +30,14 @@ for target in "${TARGETS[@]}"; do
     sbt -client "set nativeConfig ~= { _.withLTO(scala.scalanative.build.LTO.$LTO) }"
     sbt -client "set targetTriplet:= Some(\"$target\")"
     sbt -client "ninja"
-    ninja -f native/target/scala-3.4.2/native/build.ninja
+    sbt -client "ninjaCompile"
+
+    ninja -f native/target/scala-3.4.2/build.ninja
+
+    binaries+=( "$( ninja -f native/target/scala-3.4.2/build.ninja -t targets rule exe )" )
+
     echo '::endgroup::'
 done
 
-mv -v native/target/scala-3.4.2/scalals-* .
-
+mv -vt . "${binaries[@]}"
 

--- a/.github/crosscompile
+++ b/.github/crosscompile
@@ -32,9 +32,9 @@ for target in "${TARGETS[@]}"; do
     sbt -client "ninja"
     sbt -client "ninjaCompile"
 
-    ninja -f native/target/scala-3.4.2/build.ninja
+    ninja -f native/target/build.ninja
 
-    binaries+=( "$( ninja -f native/target/scala-3.4.2/build.ninja -t targets rule exe )" )
+    binaries+=( "$( ninja -f native/target/build.ninja -t targets rule exe )" )
 
     echo '::endgroup::'
 done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,10 +114,10 @@ jobs:
       env:
         SCALANATIVE_MODE: ${{ github.ref == 'refs/heads/main' && 'release-full' || 'debug' }}
     - name: qemu-aarch64 scalals
-      run: nix shell 'nixpkgs#qemu' --command qemu-aarch64 scalals-out-linux-aarch64
+      run: nix shell 'nixpkgs#qemu' --command qemu-aarch64 scalals-linux-aarch64
     - uses: actions/upload-artifact@v4
       with:
-        path: scalals-out-*
+        path: scalals-*
 
   run:
     name: Run
@@ -136,10 +136,10 @@ jobs:
       - run: |
           ls -lh
           chmod +x scalals-*
-          ./scalals-*-$( echo "${RUNNER_OS}" | tr A-Z a-z )-x86_64
         working-directory: ${{steps.download.outputs.download-path}}/artifact
-      - run: |
-          ./scalals-*-$( echo "${RUNNER_OS}" | tr A-Z a-z )-aarch64
+      - run: ./scalals-${{ runner.os == 'Linux' && 'linux' || 'darwin' }}-x86_64
+        working-directory: ${{steps.download.outputs.download-path}}/artifact
+      - run: ./scalals-${{ runner.os == 'Linux' && 'linux' || 'darwin' }}-aarch64
         if: ${{ runner.arch == 'ARM64' }}
         working-directory: ${{steps.download.outputs.download-path}}/artifact
 
@@ -155,10 +155,10 @@ jobs:
       - uses: actions/download-artifact@v4
       - name: Rename binaries
         run: |
-          mv artifact/scalals-out-linux-aarch64 scalals-arm64-linux
-          mv artifact/scalals-out-linux-x86_64 scalals-x86_64-linux
-          mv artifact/scalals-out-macos-aarch64 scalals-arm64-darwin
-          mv artifact/scalals-out-macos-x86_64 scalals-x86_64-darwin
+          mv artifact/scalals-linux-aarch64 scalals-arm64-linux
+          mv artifact/scalals-linux-x86_64 scalals-x86_64-linux
+          mv artifact/scalals-darwin-aarch64 scalals-arm64-darwin
+          mv artifact/scalals-darwin-x86_64 scalals-x86_64-darwin
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v6
         id: release

--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val scalals =
           .withCompileOptions("-Wall" :: nixCFlagsCompile ++ config.compileOptions)
           .withBaseName {
             val target = targetTriplet.value.fold("") { t =>
-              val Array(arch, os, _) = t.split("-", 3)
+              val Array(arch, _, os, _) = t.split("-", 4)
               s"-$os-$arch"
             }
             "scalals" + target

--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val scalals =
             "scalals" + target
           }
           .withLinkingOptions("-fuse-ld=lld" :: nixCFlagsLink)
+          .withMultithreading(Some(false))
           .withTargetTriple(targetTriplet.value)
       },
     )

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val scalals =
     // configure Scala-Native settings
     .nativeSettings(
       targetTriplet := None,
-      libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.5.0",
+      libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.6.0",
       nativeConfig := {
         val config = nativeConfig.value
         val nixCFlagsCompile = for {
@@ -117,18 +117,15 @@ lazy val scalals =
         } yield flag
 
         config
-          .withCompileOptions(nixCFlagsCompile)
+          .withCompileOptions("-Wall" :: nixCFlagsCompile ++ config.compileOptions)
+          .withBaseName {
+            val target = targetTriplet.value.fold("") { t =>
+              val Array(arch, os, _) = t.split("-", 3)
+              s"-$os-$arch"
+            }
+            "scalals" + target
+          }
           .withLinkingOptions("-fuse-ld=lld" :: nixCFlagsLink)
           .withTargetTriple(targetTriplet.value)
       },
-      Compile / nativeLink / artifactPath := {
-        val p = (Compile / nativeLink / artifactPath).value
-        val target = targetTriplet.value.fold("") { t =>
-          val Array(arch, os, _) = t.split("-", 3)
-          s"-$os-$arch"
-        }
-        p.getParentFile / (p.getName + target)
-      },
-      nativeCompileOptions += "-Wall",
-      nativeLinkStubs := false,
     )

--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,7 @@
               # read the first non-empty string from the VERSION file
               version = builtins.head (builtins.match "[ \n]*([^ \n]+).*" (builtins.readFile ./VERSION));
 
-              depsSha256 = "sha256-O7AbA10TRSJC0q9Oc28KTb0HkCOKzsWKgGzRGHixgKg=";
+              depsSha256 = "sha256-HF9f18HgdeLTd0NlpdKwoE4PjRRN+9MlARuhz71Tai8=";
 
               src = filter {
                 root = self;

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
     pre-commit-hooks = {
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
       url = "github:cachix/pre-commit-hooks.nix";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -151,7 +151,7 @@
 
               buildPhase = ''
                 sbt tpolecatReleaseMode 'project scalalsNative' 'show nativeConfig' ninjaCompile ninja
-                ninja -f native/target/scala-3.4.2/native/build.ninja
+                ninja -f native/target/build.ninja
               '';
 
               dontPatchELF = true;
@@ -160,7 +160,7 @@
 
               installPhase = ''
                 mkdir --parents $out/bin
-                cp native/target/scala-*/scalals-out $out/bin/scalals
+                cp "$(ninja -f native/target/build.ninja -t targets rule exe)" $out/bin/scalals
               '';
             };
             default = scalals;

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,8 @@
           mkShell = pkgs.mkShell.override { stdenv = stdenvNoCC; };
 
           clang = pkgs.writeScriptBin "clang" ''
+            #!${pkgs.bash}/bin/bash
+
             declare -a args
             for arg; do
               arg="''${arg/-unknown-/-}"
@@ -82,6 +84,8 @@
           '';
 
           clangpp = pkgs.writeScriptBin "clang++" ''
+            #!${pkgs.bash}/bin/bash
+
             declare -a args
             declare -a tmpfiles
             trap '[[ "''${#tmpfiles[@]}" -gt 0 ]] && rm -v "''${tmpfiles[@]}"' EXIT

--- a/jvm/src/main/scala/de/bley/scalals/package.scala
+++ b/jvm/src/main/scala/de/bley/scalals/package.scala
@@ -3,8 +3,5 @@ package de.bley
 package scalals:
   sealed trait Env
 
-package object scalals:
-  object EmptyEnv extends Env
-
-  @inline
-  def Env[T](f: Env => T) = f(EmptyEnv)
+  object Env extends Env:
+    inline def apply[T](inline f: Env ?=> T): T = f(using this)

--- a/native/src/main/scala/de/bley/scalals/Core.scala
+++ b/native/src/main/scala/de/bley/scalals/Core.scala
@@ -19,7 +19,7 @@ object FileInfo:
   // FIXME: crashes with a scala.scalanative.runtime.UndefinedBehaviorError
   // val lookupService = FileSystems.getDefault.getUserPrincipalLookupService
 
-  def apply(path: Path, dereference: Boolean)(implicit z: Env) =
+  def apply(path: Path, dereference: Boolean)(using e: Env) =
     val info =
       val buf = alloc[stat.stat]()
       val err =

--- a/native/src/main/scala/de/bley/scalals/Terminal.scala
+++ b/native/src/main/scala/de/bley/scalals/Terminal.scala
@@ -1,12 +1,12 @@
 package de.bley.scalals
 
-import scalanative.libc.stdio.perror
-import scalanative.unsigned.*
-import scalanative.unsafe.*
-import scalanative.posix.unistd.STDOUT_FILENO
-import scalanative.posix.fcntl.*
-import scalanative.posix.unistd.close
-import scalanative.posix.sys.ioctl.*
+import scala.scalanative.libc.stdio.perror
+import scala.scalanative.unsigned.*
+import scala.scalanative.unsafe.*
+import scala.scalanative.posix.unistd.STDOUT_FILENO
+import scala.scalanative.posix.fcntl.*
+import scala.scalanative.posix.unistd.close
+import scala.scalanative.posix.sys.ioctl.*
 
 @extern
 object termios:

--- a/project/Ninja.scala
+++ b/project/Ninja.scala
@@ -51,7 +51,7 @@ object Ninja extends AutoPlugin {
   override lazy val projectSettings = Seq(
     ninja := ninjaTask.value,
     ninjaCompile := ninjaCompileTask.value,
-    ninjaCompileFile := (Compile / crossTarget).value.toPath / "compile.ninja",
+    ninjaCompileFile := target.value.toPath / "compile.ninja",
     runNinja := runNinjaTask.value,
   )
 
@@ -177,7 +177,7 @@ object Ninja extends AutoPlugin {
           .withCompilerConfig(nativeConfig.value)
       }
       val outpath = config.artifactPath
-      val ninjaBuild = (baseDir / "build.ninja").toPath
+      val ninjaBuild = (target.value / "build.ninja").toPath
 
       val fclasspath = NativeLib.filterClasspath(config.classPath)
       val fconfig = config.withClassPath(fclasspath)

--- a/project/Ninja.scala
+++ b/project/Ninja.scala
@@ -215,7 +215,12 @@ object Ninja extends AutoPlugin {
   def addDefaultTarget(name: String): String = s"default $name\n\n"
 
   def addRules(config: Config, linkerResult: ReachabilityAnalysis.Result, outpath: Path, incdir: Path): String = {
-    val flags = opt(config) ++: flto(config) ++: ninja_target(config) :+ "-fvisibility=hidden"
+    val configFlags = {
+      if (config.compilerConfig.multithreadingSupport)
+        Seq("-DSCALANATIVE_MULTITHREADING_ENABLED")
+      else Nil
+    }
+    val cflags = opt(config) ++: flto(config) ++: ninja_target(config) ++: configFlags :+ "-fvisibility=hidden"
 
     val links = {
       val srclinks = linkerResult.links.map(_.name)
@@ -232,7 +237,7 @@ object Ninja extends AutoPlugin {
     s"""|clang = ${config.clang.abs}
         |clangpp = ${config.clangPP.abs}
         |
-        |cflags = ${flags.mkString(" ")}
+        |cflags = ${cflags.mkString(" ")}
         |
         |ldflags = ${linkflags.mkString(" ")}
         |ldopts = ${linkopts.mkString(" ")}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val scalaNativeVersion = "0.4.17"
+val scalaNativeVersion = "0.5.3"
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/shared/src/main/scala/de/bley/scalals/Core.scala
+++ b/shared/src/main/scala/de/bley/scalals/Core.scala
@@ -30,14 +30,14 @@ trait Core:
 
   def permissionString(imode: Int): String
 
-  def ls(config: Config) = Env { implicit z =>
+  def ls(config: Config) = Env {
     val items = if config.paths.isEmpty then List(Paths.get(".")) else config.paths
 
     if config.tree then tree(config, items)
     else lsNormal(config, items)
   }
 
-  private def lsNormal(config: Config, items: List[Path]) = Env { implicit z =>
+  private def lsNormal(config: Config, items: List[Path]) = Env {
     val decorators = layout(config)
 
     if config.listDirectories then


### PR DESCRIPTION
- Update scala-native to 0.5.3
- Adapt ninja plugin
- Adapt to scala-native API changes
- Set SCALANATIVE_MULTITHREADING_ENABLED when treading enabled
- Use four segment target triplets
- Adapt to new artifact names
- Call `ninjaCompile` for each target
- Generate ninja build file in native/target directory
- Update scalals dependency hash
- Remove override for flake-utils from pre-commit-hooks
