### PR TITLE
Fix CI for main branch / release-full mode

### DIFF
--- a/project/Ninja.scala
+++ b/project/Ninja.scala
@@ -253,7 +253,7 @@ object Ninja extends AutoPlugin {
         |program = $outpath
         |
         |rule cc
-        |  command = $$clang -std=gnu11 $$cflags $$auxflags -c $$in -o $$out
+        |  command = $$clang -std=gnu11 $$cflags $$auxflags -isystem $incdir -c $$in -o $$out
         |  description = compile object file (${config.gc.name} gc, $ltoName lto)
         |
         |rule ll


### PR DESCRIPTION
The process_monitor implementation was changed from C++ to C in SN 0.5.7.

This led to the compilation in `release-full` mode to fail with an error that
the `sys/posix_sem.h` file could not be found targeting x86_64 darwin.

The file is available in `native/src/main/c/include` but that directory was only
passed with `-isystem` for C++ sources.
